### PR TITLE
formatacao de LocalDateTime e paginação

### DIFF
--- a/src/main/java/com/api/parkingcontrol/configs/DateConfig.java
+++ b/src/main/java/com/api/parkingcontrol/configs/DateConfig.java
@@ -1,0 +1,25 @@
+package com.api.parkingcontrol.configs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class DateConfig {
+    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    public static LocalDateTimeSerializer LOCAL_DATETIME_SERIALIZER = new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT));
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper(){
+        JavaTimeModule module = new JavaTimeModule();
+        module.addSerializer(LOCAL_DATETIME_SERIALIZER);
+        return new ObjectMapper().registerModule(module);
+    }
+}

--- a/src/main/java/com/api/parkingcontrol/controllers/ParkingSpotController.java
+++ b/src/main/java/com/api/parkingcontrol/controllers/ParkingSpotController.java
@@ -7,6 +7,10 @@ import com.api.parkingcontrol.service.ParkingSpotService;
 import jakarta.validation.Valid;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,8 +49,9 @@ public class ParkingSpotController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ParkingSpotModel>> getAllParkingSpots(){
-        return ResponseEntity.status(HttpStatus.OK).body(parkingSpotService.findAll());
+    public ResponseEntity<Page<ParkingSpotModel>> getAllParkingSpots(@PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.ASC)
+                                                                     Pageable pageable){
+        return ResponseEntity.status(HttpStatus.OK).body(parkingSpotService.findAll(pageable));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/api/parkingcontrol/service/ParkingSpotService.java
+++ b/src/main/java/com/api/parkingcontrol/service/ParkingSpotService.java
@@ -3,6 +3,8 @@ package com.api.parkingcontrol.service;
 import com.api.parkingcontrol.models.ParkingSpotModel;
 import com.api.parkingcontrol.respositories.ParkingSpotRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,8 +35,8 @@ public class ParkingSpotService {
         return parkingSpotRepository.existsByApartmentAndBlock(apartment, block);
     }
 
-    public List<ParkingSpotModel> findAll() {
-        return parkingSpotRepository.findAll();
+    public Page<ParkingSpotModel> findAll(Pageable pageable) {
+        return parkingSpotRepository.findAll(pageable);
     }
 
     public Optional<ParkingSpotModel> findById(UUID id) {


### PR DESCRIPTION
Foi inserido a classe DateConfig dentro do pacote config para formatação de data de acordo com a norma ISO8601 UTC,
seguindo a formatação "yyyy-MM-dd'T'HH:mm:ss'Z'"

Foi modificado o método GET findAll para trabalhar com paginação.
Se não forem passados parâmetros para o método, o retorno segue a seguinte formatação:
>page = 0, size = 10, sort = "id", direction = Sort.Direction.ASC


Para o método findAll, é realizado o request com método PUT pelo endpoint:
>http://localhost:8080/parking-spot?page=0&size=5&sort=parkingSpotNumber,DESC

Também deve ser inserido um JSON no body com a seguinte estrutura:

